### PR TITLE
postpone jump out on AJAX calls for Statify 1.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Same for IPv6 prefixes like _2001:db8:a0b:12f0::/64_.
 
 ## Changelog ##
 
+### 1.5.1 / unreleased ###
+* Fix initialization on AJAX calls for _Statify_ 1.7 compatibility
+
 ### 1.5.0 / 13.05.2020 ###
 * Minimum required WordPress version is 4.7
 * Removed `load_plugin_textdomain()` and `Domain Path` header

--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -81,8 +81,8 @@ class StatifyBlacklist {
 	 * @return void
 	 */
 	public static function init() {
-		// Skip on autosave or AJAX.
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+		// Skip on autosave.
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) {
 			return;
 		}
 
@@ -95,6 +95,11 @@ class StatifyBlacklist {
 		// Add Filter to statify hook if enabled.
 		if ( 0 !== self::$options['referer']['active'] || 0 !== self::$options['target']['active'] || 0 !== self::$options['ip']['active'] ) {
 			add_filter( 'statify__skip_tracking', array( 'StatifyBlacklist', 'apply_blacklist_filter' ) );
+		}
+
+		// Statify uses WP AJAX as of 1.7, so we need to reach this point. But there are no further admin/cron actions.
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
 		}
 
 		// Admin only filters.


### PR DESCRIPTION
Statify 1.7 changed the JS tacking endpoint to WP AJAX (see pluginkollektiv/statify#109), so we must not skip the complete initialization on AJAX calls anymore.

The routine now breaks after adding the filter (if necessary).