### PR TITLE
rename plugin to "Statify Filter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Packagist Version](https://img.shields.io/packagist/v/stklcode/statify-blacklist.svg)](https://packagist.org/packages/stklcode/statify-blacklist)
 [![License](https://img.shields.io/badge/license-GPL%20v2-blue.svg)](https://github.com/stklcode/statify-blacklist/blob/master/LICENSE.md)
 
-# Statify Blacklist #
+# Statify Filter #
 * Contributors:      Stefan Kalscheuer
 * Requires at least: 4.7
 * Tested up to:      5.5
@@ -13,19 +13,19 @@
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
 ## Description ##
-A blacklist extension for the famous [Statify](https://wordpress.org/plugins/statify/) Wordpress plugin.
+A filter extension for the famous [Statify](https://wordpress.org/plugins/statify/) Wordpress plugin.
 
-This plugin adds a customizable blacklist to Statify to allow blocking of referer spam or internal interactions.
+This plugin adds customizable filters to Statify to allow blocking of referer spam or internal interactions.
 
 ### Features ##
 
-#### Referer Blacklist ####
+#### Referer Filter ####
 Add a list of domains (for simplicity only second-level, e.g. _example.com_ which blocks _everything.example.com_).
 
-#### Target Blacklist ####
+#### Target Filter ####
 Add a list of target pages (e.g. _/test/page/_, _/?page_id=123_) that will be excluded from tracking.
 
-#### IP Blacklist ####
+#### IP Filter ####
 Add a list of IP addresses or subnets (e.g. _192.0.2.123_, _198.51.100.0/24_, _2001:db8:a0b:12f0::/64_).
 
 #### CleanUp Database ####
@@ -47,7 +47,7 @@ The plugin is capable of handling multisite installations.
 ## Installation ##
 * If you don’t know how to install a plugin for WordPress, [here’s how](https://wordpress.org/support/article/managing-plugins/#installing-plugins).
 * Make sure _Statify_ plugin is installed and active
-* Goto _Settings_ -> _Statify Blacklist_ to configure the plugin
+* Goto _Settings_ -> _Statify Filter_ to configure the plugin
 
 ### Requirements ###
 * PHP 5.5 or above
@@ -57,9 +57,9 @@ The plugin is capable of handling multisite installations.
 ## Frequently Asked Questions ##
 
 ### What is blocked by default? ###
-Nothing. By default, all blacklists are empty and disabled. They can and have to be filled by the blog administrator.
+Nothing. By default, all filters are empty and disabled. They can and have to be filled by the blog administrator.
 
-A default blacklist is not provided, as the plugin itself is totally neutral. If you want to filter out referer spam, 
+A default filter is not provided, as the plugin itself is totally neutral. If you want to filter out referer spam, 
 visitors from search engines, just "false" referrers from 301 redirects or you own IP address used for testing only depends on you.
 
 ### Does the filter effect user experience? ###
@@ -77,16 +77,16 @@ Yes, it is. Just select regular expressions (case-sensitive or insensitive) as m
 
 ### Why is IP filtering only available as live filter? ###
 As you might know, _Statify_ does not store any personal information, including IP addresses in the database.
-Because of this, an IP blacklist can only be applied while processing the request and not afterwards.
+Because of this, an IP filter can only be applied while processing the request and not afterwards.
 
 ### Can whole IP subnet be blocked? ###
-Yes. The plugin features subnet blacklists using CIDR notation.
-For example _198.51.100.0/24_ blacklists all sources from _198.51.100.1_ to _198.51.100.254_.
+Yes. The plugin features subnet filters using CIDR notation.
+For example _198.51.100.0/24_ filters all sources from _198.51.100.1_ to _198.51.100.254_.
 Same for IPv6 prefixes like _2001:db8:a0b:12f0::/64_.
 
 
 ## Screenshots ##
-1. Statify Blacklist settings page
+1. Statify Filter settings page
 
 ## Changelog ##
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist Robo build script.
+ * Statify Filter Robo build script.
  *
  * This file contains the Robo tasks for building a distributable plugin package.
  * Should not be included in final package.

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
   "name": "stklcode/statify-blacklist",
-  "version": "1.5.2",
-  "description": "A blacklist extension for the famous Statify WordPress plugin",
+  "version": "1.6.0-alpha",
+  "description": "A filter extension for the famous Statify WordPress plugin",
   "keywords": [
     "wordpress",
     "plugin",
     "statistics",
-    "blacklist"
+    "filter"
   ],
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/inc/class-statifyblacklist-admin.php
+++ b/inc/class-statifyblacklist-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist: StatifyBlacklist_Admin class
+ * Statify Filter: StatifyBlacklist_Admin class
  *
  * This file contains the derived class for the plugin's administration features.
  *
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Statify Blacklist admin configuration.
+ * Statify Filter admin configuration.
  *
  * @since   1.0.0
  */
@@ -137,7 +137,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 * @since 1.0.0
 	 */
 	public static function add_menu_page() {
-		$title = __( 'Statify Blacklist', 'statify-blacklist' );
+		$title = __( 'Statify Filter', 'statify-blacklist' );
 		if ( self::$multisite ) {
 			add_submenu_page(
 				'settings.php',

--- a/inc/class-statifyblacklist-system.php
+++ b/inc/class-statifyblacklist-system.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist: StatifyBlacklist_System class
+ * Statify Filter: StatifyBlacklist_System class
  *
  * This file contains the derived class for the plugin's system operations.
  *
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Statify Blacklist system configuration.
+ * Statify Filter system configuration.
  *
  * @since   1.0.0
  */

--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist: StatifyBlacklist class
+ * Statify Filter: StatifyBlacklist class
  *
  * This file contains the plugin's base class.
  *
@@ -14,9 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Statify Blacklist.
- *
- * @since   1.0.0
+ * Statify Filter.
  */
 class StatifyBlacklist {
 
@@ -163,14 +161,14 @@ class StatifyBlacklist {
 	}
 
 	/**
-	 * Apply the blacklist filter if active
+	 * Apply the filter if active
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return bool TRUE if referer matches blacklist.
+	 * @return bool TRUE if referer matches filter.
 	 */
 	public static function apply_blacklist_filter() {
-		// Referer blacklist.
+		// Referer filter.
 		if ( isset( self::$options['referer']['active'] ) && 0 !== self::$options['referer']['active'] ) {
 			// Determine filter mode.
 			$mode = isset( self::$options['referer']['regexp'] ) ? intval( self::$options['referer']['regexp'] ) : 0;
@@ -192,7 +190,7 @@ class StatifyBlacklist {
 						self::MODE_REGEX_CI === self::$options['referer']['regexp']
 					);
 
-					// Check blacklist (no return to continue filtering #12).
+					// Check filter (no return to continue filtering #12).
 					if ( 1 === preg_match( $regexp, $referer ) ) {
 						return true;
 					}
@@ -200,7 +198,7 @@ class StatifyBlacklist {
 
 				// Keyword filter since 1.5.0 (#15).
 				case self::MODE_KEYWORD:
-					// Get blacklist.
+					// Get filter.
 					$blacklist = self::$options['referer']['blacklist'];
 
 					foreach ( array_keys( $blacklist ) as $keyword ) {
@@ -216,17 +214,17 @@ class StatifyBlacklist {
 					$referer = wp_parse_url( $referer );
 					$referer = strtolower( ( isset( $referer['host'] ) ? $referer['host'] : '' ) );
 
-					// Get blacklist.
+					// Get filter.
 					$blacklist = self::$options['referer']['blacklist'];
 
-					// Check blacklist.
+					// Check filter.
 					if ( isset( $blacklist[ $referer ] ) ) {
 						return true;
 					}
 			}
 		}
 
-		// Target blacklist (since 1.4.0).
+		// Target filter (since 1.4.0).
 		if ( isset( self::$options['target']['active'] ) && 0 !== self::$options['target']['active'] ) {
 			// Regular Expression filtering since 1.3.0.
 			if ( isset( self::$options['target']['regexp'] ) && 0 < self::$options['target']['regexp'] ) {
@@ -238,23 +236,23 @@ class StatifyBlacklist {
 					self::MODE_REGEX_CI === self::$options['target']['regexp']
 				);
 
-				// Check blacklist (no return to continue filtering #12).
+				// Check filter (no return to continue filtering #12).
 				if ( 1 === preg_match( $regexp, $target ) ) {
 					return true;
 				}
 			} else {
 				// Extract target page.
 				$target = ( isset( $_SERVER['REQUEST_URI'] ) ? filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ) : '/' );
-				// Get blacklist.
+				// Get filter.
 				$blacklist = self::$options['target']['blacklist'];
-				// Check blacklist.
+				// Check filter.
 				if ( isset( $blacklist[ $target ] ) ) {
 					return true;
 				}
 			}
 		}
 
-		// IP blacklist (since 1.4.0).
+		// IP filter (since 1.4.0).
 		if ( isset( self::$options['ip']['active'] ) && 0 !== self::$options['ip']['active'] ) {
 			$ip = self::get_ip();
 			if ( false !== ( $ip ) ) {
@@ -266,7 +264,7 @@ class StatifyBlacklist {
 			}
 		}
 
-		// Skip and continue (return NULL), if all blacklists are inactive.
+		// Skip and continue (return NULL), if all filters are inactive.
 		return null;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "statify-blacklist",
-  "version": "1.5.2",
-  "description": "A blacklist extension for the famous Statify WordPress plugin",
+  "version": "1.6.0-alpha",
+  "description": "A filter extension for the famous Statify WordPress plugin",
   "author": "Stefan Kalscheuer",
   "license": "GPL-2.0+"
 }

--- a/statify-blacklist.php
+++ b/statify-blacklist.php
@@ -1,33 +1,33 @@
 <?php
 /**
- * Statify Blacklist
+ * Statify Filter
  *
  * @package     PluginPackage
  * @author      Stefan Kalscheuer <stefan@stklcode.de>
  * @license     GPL-2.0+
  *
  * @wordpress-plugin
- * Plugin Name: Statify Blacklist
+ * Plugin Name: Statify Filter
  * Plugin URI:  https://wordpress.org/plugins/statify-blacklist/
- * Description: Extension for the Statify plugin to add a customizable blacklists.
- * Version:     1.5.2
+ * Description: Extension for the Statify plugin to add customizable filters. (formerly "Statify Blacklist)
+ * Version:     1.6.0-alpha
  * Author:      Stefan Kalscheuer (@stklcode)
  * Author URI:  https://www.stklcode.de
  * Text Domain: statify-blacklist
  * License:     GPLv2 or later
  *
- * Statify Blacklist is free software: you can redistribute it and/or modify
+ * Statify Filter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * any later version.
  *
- * Statify Blacklist is distributed in the hope that it will be useful,
+ * Statify Filter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Statify Blacklist. If not, see https://www.gnu.org/licenses/gpl-2.0.html.
+ * along with Statify Filter. If not, see https://www.gnu.org/licenses/gpl-2.0.html.
  */
 
 // Quit if accessed directly.
@@ -124,7 +124,7 @@ function statify_blacklist_disabled_notice() {
 	echo '<div class="notice notice-error is-dismissible"><p><strong>';
 	printf(
 		/* translators: minimum version numbers for WordPress and PHP inserted at placeholders */
-		esc_html__( 'Statify Blacklist requires at least WordPress %1$s and PHP %2$s.', 'statify-blacklist' ),
+		esc_html__( 'Statify Filter requires at least WordPress %1$s and PHP %2$s.', 'statify-blacklist' ),
 		'4.7',
 		'5.5'
 	);

--- a/test/statifyblacklist-test.php
+++ b/test/statifyblacklist-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist: Unit Test
+ * Statify Filter: Unit Test
  *
  * This is a PHPunit test class for the plugin's functionality
  *
@@ -47,7 +47,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 */
 	public function test_referer_filter() {
-		// Prepare Options: 2 blacklisted domains, disabled.
+		// Prepare Options: 2 filtered domains, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
 				'active'    => 0,
@@ -77,13 +77,13 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 		// No referer.
 		unset( $_SERVER['HTTP_REFERER'] );
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Non-blacklisted referer.
+		// Non-filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://example.org';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer.
+		// Filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://example.com';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer with path.
+		// Filtered referer with path.
 		$_SERVER['HTTP_REFERER'] = 'http://example.net/foo/bar.html';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
 
@@ -139,13 +139,13 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 		// No referer.
 		unset( $_SERVER['HTTP_REFERER'] );
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Non-blacklisted referer.
+		// Non-filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://not.evil';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer.
+		// Filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://example.com';
 		$this->assertTrue( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer with path.
+		// Filtered referer with path.
 		$_SERVER['HTTP_REFERER'] = 'http://foobar.net/test/me';
 		$this->assertTrue( StatifyBlacklist::apply_blacklist_filter() );
 		// Matching both.
@@ -196,13 +196,13 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 		// No referer.
 		unset( $_SERVER['HTTP_REFERER'] );
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Non-blacklisted referer.
+		// Non-filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://not.evil';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer.
+		// Filtered referer.
 		$_SERVER['HTTP_REFERER'] = 'http://example.com';
 		$this->assertTrue( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer with path.
+		// Filtered referer with path.
 		$_SERVER['HTTP_REFERER'] = 'http://foobar.net/test/me';
 		$this->assertTrue( StatifyBlacklist::apply_blacklist_filter() );
 		// Matching both.
@@ -405,7 +405,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 */
 	public function test_ip_filter() {
-		// Prepare Options: 2 blacklisted IPs, disabled.
+		// Prepare Options: 2 filtered IPs, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
 				'active'    => 0,
@@ -477,7 +477,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 */
 	public function test_target_filter() {
-		// Prepare Options: 2 blacklisted domains, disabled.
+		// Prepare Options: 2 filtered domains, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
 				'active'    => 0,
@@ -507,14 +507,14 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 		// Empty target.
 		unset( $_SERVER['REQUEST_URI'] );
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Non-blacklisted targets.
+		// Non-filtered targets.
 		$_SERVER['REQUEST_URI'] = '';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
 		$_SERVER['REQUEST_URI'] = '/';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
 		$_SERVER['REQUEST_URI'] = '/?page_id=1';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
-		// Blacklisted referer.
+		// Filtered referer.
 		$_SERVER['REQUEST_URI'] = '/excluded/page/';
 		$this->assertNull( StatifyBlacklist::apply_blacklist_filter() );
 		$_SERVER['REQUEST_URI'] = '/?page_id=3';

--- a/views/settings-page.php
+++ b/views/settings-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Statify Blacklist: Settings View
+ * Statify Filter: Settings View
  *
  * This file contains the dynamic HTML skeleton for the plugin's settings page.
  *
@@ -146,7 +146,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 ?>
 
 <div class="wrap">
-	<h1><?php esc_html_e( 'Statify Blacklist', 'statify-blacklist' ); ?></h1>
+	<h1><?php esc_html_e( 'Statify Filter', 'statify-blacklist' ); ?></h1>
 	<?php
 	if ( is_plugin_inactive( 'statify/statify.php' ) ) {
 		print '<div class="notice notice-warning"><p>';
@@ -170,7 +170,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 	<form action="" method="post" id="statify-blacklist-settings">
 		<?php wp_nonce_field( 'statify-blacklist-settings' ); ?>
 
-		<h2><?php esc_html_e( 'Referer blacklist', 'statify-blacklist' ); ?></h2>
+		<h2><?php esc_html_e( 'Referer filter', 'statify-blacklist' ); ?></h2>
 
 		<table class="form-table">
 			<tbody>
@@ -232,7 +232,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 			</tr>
 			<tr>
 				<th scope="row">
-					<label for="statify-blacklist_referer"><?php esc_html_e( 'Referer blacklist', 'statify-blacklist' ); ?></label>
+					<label for="statify-blacklist_referer"><?php esc_html_e( 'Referer filter', 'statify-blacklist' ); ?></label>
 				</th>
 				<td>
 					<textarea cols="40" rows="5" name="statifyblacklist[referer][blacklist]" id="statify-blacklist_referer"><?php
@@ -250,7 +250,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 			</tbody>
 		</table>
 
-		<h2><?php esc_html_e( 'Target blacklist', 'statify-blacklist' ); ?></h2>
+		<h2><?php esc_html_e( 'Target filter', 'statify-blacklist' ); ?></h2>
 
 		<table class="form-table">
 			<tbody>
@@ -312,7 +312,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 			<tr>
 				<th scope="row">
 					<label for="statify-blacklist_target">
-						<?php esc_html_e( 'Target blacklist', 'statify-blacklist' ); ?>
+						<?php esc_html_e( 'Target filter', 'statify-blacklist' ); ?>
 					</label>
 				</th>
 				<td>
@@ -332,7 +332,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 			</tbody>
 		</table>
 
-		<h2><?php esc_html_e( 'IP blacklist', 'statify-blacklist' ); ?></h2>
+		<h2><?php esc_html_e( 'IP filter', 'statify-blacklist' ); ?></h2>
 
 		<table class="form-table">
 			<tbody>
@@ -354,7 +354,7 @@ if ( ! empty( $_POST['statifyblacklist'] ) ) {
 			</tr>
 			<tr>
 				<th scope="row">
-					<label for="statify-blacklist_ip"><?php esc_html_e( 'IP blacklist', 'statify-blacklist' ); ?></label>:
+					<label for="statify-blacklist_ip"><?php esc_html_e( 'IP filter', 'statify-blacklist' ); ?></label>:
 				</th>
 				<td>
 					<textarea cols="40" rows="5" name="statifyblacklist[ip][blacklist]" id="statify-blacklist_ip"><?php


### PR DESCRIPTION
The plugins purpose is to exclude or filter certain requests from tracking by _Statify_. However the current name "_Statify Blacklist_" is not actually inline with today's understanding of such terms. In _WordPress_ Core 5.5 the word "blacklist" among others has been replaced by more precise wording where possible<sup>[1](#fn1)</sup>.

The term "filter" has been used in various places already and clearly describes the behavior of this plugin. So we rename the plugin to "_Statify Filter_" and rephrase front-end texts.

Plugin slug (permalink), textdomain and all public class and constant names left untouched for now, to not introduce breaking changes at this point. To be cleaned up with next major release.

[<a name="fn1">1</a>] https://make.wordpress.org/core/2020/07/23/codebase-language-improvements-in-5-5/