### PR TITLE
fix option upgrade routine

### DIFF
--- a/inc/class-statifyblacklist-system.php
+++ b/inc/class-statifyblacklist-system.php
@@ -205,7 +205,7 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 		// Version older than current major release.
 		if ( self::VERSION_MAIN > self::$options['version'] ) {
 			// Merge default options with current config, assuming only additive changes.
-			$options            = array_merge_recursive( self::default_options(), self::$options );
+			$options            = array_replace_recursive( self::default_options(), self::$options );
 			$options['version'] = self::VERSION_MAIN;
 			if ( self::$multisite ) {
 				update_site_option( 'statify-blacklist', $options );

--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -22,9 +22,9 @@ class StatifyBlacklist {
 	 * Plugin major version.
 	 *
 	 * @since 1.4.0
-	 * @var int VERSION_MAIN
+	 * @var float VERSION_MAIN
 	 */
-	const VERSION_MAIN = 1.6;
+	const VERSION_MAIN = 1.7;
 
 	/**
 	 * Operation mode "normal".

--- a/test/StatifyBlacklist_System_Test.php
+++ b/test/StatifyBlacklist_System_Test.php
@@ -47,7 +47,7 @@ class StatifyBlacklist_System_Test extends PHPUnit\Framework\TestCase {
 		$this->assertEquals( 4, count( $options_updated['target'] ) );
 		$this->assertEquals( 2, count( $options_updated['ip'] ) );
 		$this->assertEquals( 3, count( $options_updated['ua'] ) );
-		$this->assertEquals( 1.6, $options_updated['version'] );
+		$this->assertEquals( StatifyBlacklist::VERSION_MAIN, $options_updated['version'] );
 
 		// Verify that original attributes are unchanged.
 		$this->assertEquals( $options13['active_referer'], $options_updated['referer']['active'] );
@@ -86,7 +86,6 @@ class StatifyBlacklist_System_Test extends PHPUnit\Framework\TestCase {
 			),
 			$options_updated['ua']['blacklist']
 		);
-		$this->assertEquals( 1.6, $options_updated['version'] );
 		$this->assertEquals( StatifyBlacklist::VERSION_MAIN, $options_updated['version'] );
 	}
 }


### PR DESCRIPTION
Upgrading options without changes utilizes `array_merge_recursive()` to merge (potentially updated) default settings with current options.

With something like
```
[
  'active' => 1,
  ...
]
```
and default
```
[
  'active' => 1,
  ...
]
```

this results in
```
[
  'active' => [ 0, 1 ],
  ...
]
```

Because we have custom routines in place for 1.4 and 1.6 and we skipped 1.5 this was not a real issue. Noticed when updating the version to 1.7 without option changes.

Replace the merge function by `array_replace_recursive()` resolves the issue for now.