### PR TITLE
update minimum supported PHP version to 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.6', '7.4', '8.0', '8.2', '8.4' ]
+        php: [ '7.4', '8.0', '8.2', '8.4' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Contributors:      stklcode
 * Requires at least: 4.7
 * Tested up to:      6.8
-* Requires PHP:      5.5
+* Requires PHP:      7.2
 * Stable tag:        1.7.2
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -55,7 +55,7 @@ The plugin is capable of handling multisite installations.
 * Goto _Settings_ -> _Statify Filter_ to configure the plugin
 
 ### Requirements ###
-* PHP 5.5 or above
+* PHP 7.2 or above
 * WordPress 4.7 or above
 * _Statify_ plugin installed and activated (1.5 or above)
 

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,16 @@
   ],
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=5.5",
-    "composer/installers": "~v1.12|~v2.3"
+    "php": ">=7.2",
+    "composer/installers": "~v2.3"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^v1.0",
-    "phpunit/phpunit": "^5|^6|^7|^8|^9",
-    "phpunit/php-code-coverage": "*",
+    "dealerdirect/phpcodesniffer-composer-installer": "^v1.1",
+    "phpunit/phpunit": "^8|^9",
     "slowprog/composer-copy-file": "~0.3",
-    "squizlabs/php_codesniffer": "^3.12",
+    "squizlabs/php_codesniffer": "^3.13",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "wp-coding-standards/wpcs": "^3.1"
+    "wp-coding-standards/wpcs": "^3.2"
   },
   "scripts": {
     "test-all": [

--- a/inc/class-statifyblacklist-admin.php
+++ b/inc/class-statifyblacklist-admin.php
@@ -26,7 +26,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @since 1.5.0
 	 */
-	public static function init() {
+	public static function init(): void {
 		// Add actions.
 		add_action( 'wpmu_new_blog', array( 'StatifyBlacklist_System', 'install_site' ) );
 		add_action( 'delete_blog', array( 'StatifyBlacklist_System', 'uninstall_site' ) );
@@ -55,7 +55,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @since 1.0.0
 	 */
-	public static function add_menu_page() {
+	public static function add_menu_page(): void {
 		$title = __( 'Statify Filter', 'statify-blacklist' );
 		if ( self::$multisite ) {
 			add_options_page(
@@ -86,7 +86,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @since 1.0.0
 	 */
-	public static function plugin_meta_link( $links, $file ) {
+	public static function plugin_meta_link( array $links, string $file ): array {
 		if ( STATIFYBLACKLIST_BASE === $file ) {
 			$links[] = '<a href="https://github.com/stklcode/statify-blacklist">GitHub</a>';
 		}
@@ -104,7 +104,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @since 1.0.0
 	 */
-	public static function plugin_actions_links( $links, $file ) {
+	public static function plugin_actions_links( array $links, string $file ): array {
 		$base = self::$multisite ? network_admin_url( 'settings.php' ) : admin_url( 'options-general.php' );
 
 		if ( STATIFYBLACKLIST_BASE === $file && current_user_can( 'manage_options' ) ) {
@@ -124,7 +124,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @global wpdb $wpdb WordPress database.
 	 */
-	public static function cleanup_database() {
+	public static function cleanup_database(): void {
 		// Check user permissions.
 		if ( ! current_user_can( 'manage_options' ) && ! ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
 			die( esc_html__( 'Are you sure you want to do this?', 'statify-blacklist' ) );
@@ -206,7 +206,7 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 *
 	 * @since 1.1.1
 	 */
-	private static function sanitize_urls( $urls ) {
+	private static function sanitize_urls( array $urls ): array {
 		return array_flip(
 			array_filter(
 				array_map(

--- a/inc/class-statifyblacklist-settings.php
+++ b/inc/class-statifyblacklist-settings.php
@@ -20,7 +20,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function register_settings() {
+	public static function register_settings(): void {
 		register_setting(
 			'statify-blacklist',
 			'statify-blacklist',
@@ -166,7 +166,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function create_settings_page() {
+	public static function create_settings_page(): void {
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Statify Filter', 'statify-blacklist' ); ?></h1>
@@ -225,7 +225,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_referer_active() {
+	public static function option_referer_active(): void {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'Activate live filter', 'statify-blacklist' ); ?></legend>
@@ -245,7 +245,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_referer_cron() {
+	public static function option_referer_cron(): void {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'CronJob execution', 'statify-blacklist' ); ?></legend>
@@ -265,7 +265,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_referer_regexp() {
+	public static function option_referer_regexp(): void {
 		?>
 		<select id="statifyblacklist-referer-regexp" name="statify-blacklist[referer][regexp]">
 			<option value="<?php print esc_attr( StatifyBlacklist::MODE_NORMAL ); ?>" <?php selected( StatifyBlacklist::$options['referer']['regexp'], StatifyBlacklist::MODE_NORMAL ); ?>>
@@ -296,7 +296,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_referer_blacklist() {
+	public static function option_referer_blacklist(): void {
 		?>
 		<textarea id="statifyblacklist-referer-blacklist" name="statify-blacklist[referer][blacklist]" cols="40" rows="5"><?php
 		print esc_html( implode( "\r\n", array_keys( StatifyBlacklist::$options['referer']['blacklist'] ) ) );
@@ -312,7 +312,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_target_active() {
+	public static function option_target_active(): void {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'Activate live filter', 'statify-blacklist' ); ?></legend>
@@ -332,7 +332,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_target_cron() {
+	public static function option_target_cron(): void {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'CronJob execution', 'statify-blacklist' ); ?></legend>
@@ -352,7 +352,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_target_regexp() {
+	public static function option_target_regexp(): void {
 		?>
 		<select id="statifyblacklist-target-regexp" name="statify-blacklist[target][regexp]">
 			<option value="<?php print esc_attr( StatifyBlacklist::MODE_NORMAL ); ?>" <?php selected( StatifyBlacklist::$options['target']['regexp'], StatifyBlacklist::MODE_NORMAL ); ?>>
@@ -378,7 +378,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_target_blacklist() {
+	public static function option_target_blacklist(): void {
 		?>
 		<textarea id="statifyblacklist-target-blacklist" name="statify-blacklist[target][blacklist]" cols="40" rows="5"><?php
 		print esc_html( implode( "\r\n", array_keys( StatifyBlacklist::$options['target']['blacklist'] ) ) );
@@ -394,7 +394,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_ip_active() {
+	public static function option_ip_active(): void {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'Activate live filter', 'statify-blacklist' ); ?></legend>
@@ -416,7 +416,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_ip_blacklist() {
+	public static function option_ip_blacklist(): void {
 		?>
 		<textarea id="statifyblacklist-ip-blacklist" name="statify-blacklist[ip][blacklist]" cols="40" rows="5"><?php
 		print esc_html( implode( "\r\n", StatifyBlacklist::$options['ip']['blacklist'] ) );
@@ -433,7 +433,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_ua_active() {
+	public static function option_ua_active(): void {
 		?>
 		<label for="statifyblacklist-ua-active">
 			<input id="statifyblacklist-ua-active" name="statify-blacklist[ua][active]" type="checkbox" value="1" <?php checked( StatifyBlacklist::$options['ua']['active'], 1 ); ?>>
@@ -453,7 +453,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_ua_regexp() {
+	public static function option_ua_regexp(): void {
 		?>
 		<select id="statifyblacklist-ua-regexp" name="statify-blacklist[ua][regexp]">
 			<option value="<?php print esc_attr( StatifyBlacklist::MODE_NORMAL ); ?>" <?php selected( StatifyBlacklist::$options['ua']['regexp'], StatifyBlacklist::MODE_NORMAL ); ?>>
@@ -484,7 +484,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function option_ua_blacklist() {
+	public static function option_ua_blacklist(): void {
 		?>
 		<textarea name="statify-blacklist[ua][blacklist]" id="statifyblacklist-ua-blacklist" cols="40" rows="5"><?php
 		print esc_html( implode( "\r\n", StatifyBlacklist::$options['ua']['blacklist'] ) );
@@ -503,7 +503,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return array Validated and sanitized options.
 	 */
-	public static function sanitize_options( $options ) {
+	public static function sanitize_options( array $options ): array {
 		// Extract filter lists from multi-line inputs.
 		$referer = self::parse_multiline_option( $options['referer']['blacklist'] );
 		$target  = self::parse_multiline_option( $options['target']['blacklist'] );
@@ -553,7 +553,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @since 1.7.0
 	 */
-	private static function sanitize_referer_options( &$options ) {
+	private static function sanitize_referer_options( array &$options ): void {
 		$referer_given   = $options['blacklist'];
 		$referer_invalid = array();
 		if ( StatifyBlacklist::MODE_NORMAL === $options['regexp'] ) {
@@ -596,7 +596,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @since 1.7.0
 	 */
-	private static function sanitize_target_options( &$options ) {
+	private static function sanitize_target_options( array &$options ): void {
 		$target_given     = $options['blacklist'];
 		$target_sanitized = $target_given;
 		if ( StatifyBlacklist::MODE_REGEX === $options['regexp'] || StatifyBlacklist::MODE_REGEX_CI === $options['regexp'] ) {
@@ -626,7 +626,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @since 1.7.0
 	 */
-	private static function sanitize_ip_options( &$options ) {
+	private static function sanitize_ip_options( array &$options ): void {
 		$given_ip             = $options['blacklist'];
 		$sanitized_ip         = self::sanitize_ips( $given_ip );
 		$ip_diff              = array_diff( $given_ip, $sanitized_ip );
@@ -654,7 +654,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 * @since 1.1.1
 	 * @since 1.7.0 moved from StatifyBlacklist_Admin to StatifyBlacklist_Settings.
 	 */
-	private static function sanitize_urls( $urls ) {
+	private static function sanitize_urls( array $urls ): array {
 		return array_flip(
 			array_filter(
 				array_map(
@@ -677,7 +677,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 * @since 1.4.0
 	 * @since 1.7.0 moved from StatifyBlacklist_Admin to StatifyBlacklist_Settings.
 	 */
-	private static function sanitize_ips( $ips ) {
+	private static function sanitize_ips( array $ips ): array {
 		return array_values(
 			array_unique(
 				array_filter(
@@ -713,7 +713,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 * @since 1.5.0 #13
 	 * @since 1.7.0 moved from StatifyBlacklist_Admin to StatifyBlacklist_Settings.
 	 */
-	private static function sanitize_regex( $expressions ) {
+	private static function sanitize_regex( array $expressions ): array {
 		return array_filter(
 			array_flip( $expressions ),
 			function ( $re ) {
@@ -732,7 +732,7 @@ class StatifyBlacklist_Settings extends StatifyBlacklist {
 	 *
 	 * @return array Parsed options.
 	 */
-	private static function parse_multiline_option( $raw ) {
+	private static function parse_multiline_option( string $raw ): array {
 		if ( empty( trim( $raw ) ) ) {
 			return array();
 		} else {

--- a/inc/class-statifyblacklist-system.php
+++ b/inc/class-statifyblacklist-system.php
@@ -30,7 +30,7 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function install( $network_wide = false ) {
+	public static function install( bool $network_wide = false ): void {
 		// Create tables for each site in a network.
 		if ( $network_wide && is_multisite() ) {
 			if ( function_exists( 'get_sites' ) ) {
@@ -66,8 +66,8 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function install_site( $site_id ) {
-		switch_to_blog( (int) $site_id );
+	public static function install_site( int $site_id ): void {
+		switch_to_blog( $site_id );
 		add_option(
 			'statify-blacklist',
 			self::default_options()
@@ -83,7 +83,7 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function uninstall() {
+	public static function uninstall(): void {
 		if ( is_multisite() ) {
 			$old = get_current_blog_id();
 
@@ -117,9 +117,9 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function uninstall_site( $site_id ) {
+	public static function uninstall_site( int $site_id ): void {
 		$old = get_current_blog_id();
-		switch_to_blog( (int) $site_id );
+		switch_to_blog( $site_id );
 		delete_option( 'statify-blacklist' );
 		switch_to_blog( $old );
 	}
@@ -131,7 +131,7 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function upgrade() {
+	public static function upgrade(): void {
 		self::update_options();
 		// Check if config array is not associative (pre 1.2.0).
 		if ( array_keys( self::$options['referer'] ) === range( 0, count( self::$options['referer'] ) - 1 ) ) {

--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -78,7 +78,7 @@ class StatifyBlacklist {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		// Skip on autosave.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
@@ -121,11 +121,11 @@ class StatifyBlacklist {
 	 * @since 1.0.0
 	 * @since 1.2.1 update_options($options = null) Parameter with default value introduced.
 	 *
-	 * @param array $options Optional. New options to save.
+	 * @param array|null $options Optional. New options to save.
 	 *
 	 * @return void
 	 */
-	public static function update_options( $options = null ) {
+	public static function update_options( ?array $options = null ): void {
 		if ( self::$multisite ) {
 			$o = get_site_option( 'statify-blacklist' );
 		} else {
@@ -141,7 +141,7 @@ class StatifyBlacklist {
 	 *
 	 * @return array The options array.
 	 */
-	protected static function default_options() {
+	protected static function default_options(): array {
 		return array(
 			'referer' => array(
 				'active'    => 0,
@@ -173,9 +173,9 @@ class StatifyBlacklist {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return bool TRUE if referer matches filter.
+	 * @return bool|null TRUE if referer matches filter.
 	 */
-	public static function apply_blacklist_filter() {
+	public static function apply_blacklist_filter(): ?bool {
 		// Referer filter.
 		if (
 		self::apply_single_filter(
@@ -225,7 +225,7 @@ class StatifyBlacklist {
 	 *
 	 * @since 1.6 Extracted from "apply_blacklist_filter" to reduce redundancies.
 	 */
-	private static function apply_single_filter( $config, $value_fn ) {
+	private static function apply_single_filter( array $config, callable $value_fn ): bool {
 		// Is the filter active?
 		if ( ! isset( $config['active'] ) || 0 === $config['active'] ) {
 			return false;
@@ -281,7 +281,7 @@ class StatifyBlacklist {
 	 *
 	 * @return string Preprocessed expression ready for preg_match().
 	 */
-	protected static function regex( $expression, $case_insensitive ) {
+	protected static function regex( $expression, $case_insensitive ): string {
 		$res = '/';
 		if ( is_string( $expression ) ) {
 			$res .= str_replace( '/', '\/', $expression );
@@ -309,7 +309,7 @@ class StatifyBlacklist {
 	 *
 	 * @return string The referer.
 	 */
-	private static function get_referer() {
+	private static function get_referer(): string {
 		$referer = wp_get_raw_referer();
 		if ( ! $referer ) {
 			$referer = '';
@@ -323,7 +323,7 @@ class StatifyBlacklist {
 	 *
 	 * @return string Referer domain.
 	 */
-	private static function get_referer_domain() {
+	private static function get_referer_domain(): string {
 		$referer = wp_parse_url( self::get_referer() );
 
 		return strtolower( ( isset( $referer['host'] ) ? $referer['host'] : '' ) );
@@ -334,7 +334,7 @@ class StatifyBlacklist {
 	 *
 	 * @return string The referer.
 	 */
-	private static function get_target() {
+	private static function get_target(): string {
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			$target = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
 			if ( $target ) {
@@ -386,7 +386,7 @@ class StatifyBlacklist {
 	 *
 	 * @return string The user agent string.
 	 */
-	private static function get_user_agent() {
+	private static function get_user_agent(): string {
 		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			$user_agent = filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
 			if ( $user_agent ) {
@@ -405,7 +405,7 @@ class StatifyBlacklist {
 	 *
 	 * @return bool TRUE, if the given IP addresses matches the given subnet.
 	 */
-	private static function cidr_match( $ip, $net ) {
+	private static function cidr_match( string $ip, string $net ): bool {
 		if ( substr_count( $net, ':' ) > 1 ) {  // Check for IPv6.
 			if ( ! ( ( extension_loaded( 'sockets' ) && defined( 'AF_INET6' ) ) || inet_pton( '::1' ) ) ) {
 				return false;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,6 +24,6 @@
 	</rule>
 
 	<!-- PHP compatibility level -->
-	<config name="testVersion" value="5.5-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP"/>
 </ruleset>

--- a/statify-blacklist.php
+++ b/statify-blacklist.php
@@ -69,7 +69,7 @@ if ( statify_blacklist_compatibility_check() ) {
  *
  * @since 1.0.0
  */
-function statify_blacklist_autoload( $class_name ) {
+function statify_blacklist_autoload( string $class_name ): void {
 	$plugin_classes = array(
 		'StatifyBlacklist',
 		'StatifyBlacklist_Admin',
@@ -93,7 +93,7 @@ function statify_blacklist_autoload( $class_name ) {
  *
  * @return boolean Whether minimum WP and PHP versions are met.
  */
-function statify_blacklist_compatibility_check() {
+function statify_blacklist_compatibility_check(): bool {
 	return version_compare( $GLOBALS['wp_version'], '4.7', '>=' ) &&
 		version_compare( phpversion(), '7.2', '>=' );
 }
@@ -105,7 +105,7 @@ function statify_blacklist_compatibility_check() {
  *
  * @return void
  */
-function statify_blacklist_disable() {
+function statify_blacklist_disable(): void {
 	if ( is_plugin_active( STATIFYBLACKLIST_BASE ) ) {
 		deactivate_plugins( STATIFYBLACKLIST_BASE );
 		add_action( 'admin_notices', 'statify_blacklist_disabled_notice' );
@@ -124,7 +124,7 @@ function statify_blacklist_disable() {
  *
  * @return void
  */
-function statify_blacklist_disabled_notice() {
+function statify_blacklist_disabled_notice(): void {
 	echo '<div class="notice notice-error is-dismissible"><p><strong>';
 	printf(
 		/* translators: minimum version numbers for WordPress and PHP inserted at placeholders */

--- a/statify-blacklist.php
+++ b/statify-blacklist.php
@@ -12,7 +12,7 @@
  * Description:       Extension for the Statify plugin to add customizable filters. (formerly "Statify Blacklist")
  * Version:           1.7.2
  * Requires at least: 4.7
- * Requires PHP:      5.5
+ * Requires PHP:      7.2
  * Requires Plugins:  statify
  * Author:            Stefan Kalscheuer (@stklcode)
  * Author URI:        https://www.stklcode.de
@@ -95,7 +95,7 @@ function statify_blacklist_autoload( $class_name ) {
  */
 function statify_blacklist_compatibility_check() {
 	return version_compare( $GLOBALS['wp_version'], '4.7', '>=' ) &&
-		version_compare( phpversion(), '5.5', '>=' );
+		version_compare( phpversion(), '7.2', '>=' );
 }
 
 /**
@@ -130,7 +130,7 @@ function statify_blacklist_disabled_notice() {
 		/* translators: minimum version numbers for WordPress and PHP inserted at placeholders */
 		esc_html__( 'Statify Filter requires at least WordPress %1$s and PHP %2$s.', 'statify-blacklist' ),
 		'4.7',
-		'5.5'
+		'7.2'
 	);
 	echo '<br>';
 	printf(

--- a/test/StatifyBlacklist_Settings_Test.php
+++ b/test/StatifyBlacklist_Settings_Test.php
@@ -19,7 +19,7 @@ class StatifyBlacklist_Settings_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_sanitize_options() {
+	public function test_sanitize_options(): void {
 		global $settings_error;
 
 		// Emulate default submission: nothing checked, all textareas empty.
@@ -215,7 +215,7 @@ class StatifyBlacklist_Settings_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_sanitize_ips() {
+	public function test_sanitize_ips(): void {
 		// IPv4 tests.
 		$valid   = array( '192.0.2.123', '192.0.2.123/32', '192.0.2.0/24', '192.0.2.128/25' );
 		$invalid = array( '12.34.56.789', '192.0.2.123/33', '192.0.2.123/-1' );
@@ -276,7 +276,7 @@ class StatifyBlacklist_Settings_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_register_settings() {
+	public function test_register_settings(): void {
 		global $settings;
 		$settings = array();
 

--- a/test/StatifyBlacklist_System_Test.php
+++ b/test/StatifyBlacklist_System_Test.php
@@ -19,7 +19,7 @@ class StatifyBlacklist_System_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_upgrade() {
+	public function test_upgrade(): void {
 		// Create configuration of version 1.3.
 		$options13 = array(
 			'active_referer' => 1,

--- a/test/StatifyBlacklist_Test.php
+++ b/test/StatifyBlacklist_Test.php
@@ -22,7 +22,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_referer_filter() {
+	public function test_referer_filter(): void {
 		// Prepare Options: 2 filtered domains, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -89,7 +89,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_referer_regex_filter() {
+	public function test_referer_regex_filter(): void {
 		// Prepare Options: 2 regular expressions.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -151,7 +151,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_referer_keyword_filter() {
+	public function test_referer_keyword_filter(): void {
 		// Prepare Options: 2 regular expressions.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -209,7 +209,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_cidr_match() {
+	public function test_cidr_match(): void {
 		// IPv4 tests.
 		$this->assertTrue( invoke_static( StatifyBlacklist::class, 'cidr_match', array( '127.0.0.1', '127.0.0.1' ) ) );
 		$this->assertTrue( invoke_static( StatifyBlacklist::class, 'cidr_match', array( '127.0.0.1', '127.0.0.1/32' ) ) );
@@ -311,7 +311,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_ip_filter() {
+	public function test_ip_filter(): void {
 		// Prepare Options: 2 filtered IPs, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -388,7 +388,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_target_filter() {
+	public function test_target_filter(): void {
 		// Prepare Options: 2 filtered domains, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -466,7 +466,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_ua_filter() {
+	public function test_ua_filter(): void {
 		// Prepare Options: 2 filtered IPs, disabled.
 		StatifyBlacklist::$options = array(
 			'referer' => array(
@@ -531,7 +531,7 @@ class StatifyBlacklist_Test extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_combined_filters() {
+	public function test_combined_filters(): void {
 		// Prepare Options: simple referer + simple target + ip.
 		StatifyBlacklist::$options = array(
 			'referer' => array(


### PR DESCRIPTION
_Statify_ will move to 7.2 (pluginkollektiv/statify#287), so there is no reason to stick with PHP 5 with
the upcoming release.