### PR TITLE
use wp_doing_ajax() instead of constant checking

### DIFF
--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -99,7 +99,7 @@ class StatifyBlacklist {
 		}
 
 		// Statify uses WP AJAX as of 1.7, so we need to reach this point. But there are no further admin/cron actions.
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		if ( wp_doing_ajax() ) {
 			return;
 		}
 


### PR DESCRIPTION
The function is available since WP 4.7, so we could have been using it since v1.5. It defaults to the same logic but applies an additional filter internally.