### PR TITLE
update minimum supported WordPress version to 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Statify Filter #
 * Contributors:      stklcode
-* Requires at least: 4.7
+* Requires at least: 5.1
 * Tested up to:      6.8
 * Requires PHP:      7.2
 * Stable tag:        1.7.2
@@ -56,7 +56,7 @@ The plugin is capable of handling multisite installations.
 
 ### Requirements ###
 * PHP 7.2 or above
-* WordPress 4.7 or above
+* WordPress 5.1 or above
 * _Statify_ plugin installed and activated (1.5 or above)
 
 ## Frequently Asked Questions ##

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
 	<file>inc</file>
 
 	<!-- Compliance with WordPress Coding Standard -->
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="minimum_supported_wp_version" value="5.1"/>
 	<rule ref="WordPress">
 		<!-- Direct queries used to clean up statify table. -->
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>

--- a/statify-blacklist.php
+++ b/statify-blacklist.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://wordpress.org/plugins/statify-blacklist/
  * Description:       Extension for the Statify plugin to add customizable filters. (formerly "Statify Blacklist")
  * Version:           1.7.2
- * Requires at least: 4.7
+ * Requires at least: 5.1
  * Requires PHP:      7.2
  * Requires Plugins:  statify
  * Author:            Stefan Kalscheuer (@stklcode)
@@ -94,7 +94,7 @@ function statify_blacklist_autoload( string $class_name ): void {
  * @return boolean Whether minimum WP and PHP versions are met.
  */
 function statify_blacklist_compatibility_check(): bool {
-	return version_compare( $GLOBALS['wp_version'], '4.7', '>=' ) &&
+	return version_compare( $GLOBALS['wp_version'], '5.1', '>=' ) &&
 		version_compare( phpversion(), '7.2', '>=' );
 }
 
@@ -129,7 +129,7 @@ function statify_blacklist_disabled_notice(): void {
 	printf(
 		/* translators: minimum version numbers for WordPress and PHP inserted at placeholders */
 		esc_html__( 'Statify Filter requires at least WordPress %1$s and PHP %2$s.', 'statify-blacklist' ),
-		'4.7',
+		'5.1',
 		'7.2'
 	);
 	echo '<br>';


### PR DESCRIPTION
Statify will move to 5.1 (pluginkollektiv/statify#287), so there is no reason to stick with WP 4.7 with the upcoming release.