### PR TITLE
use wp_doing_cron() instead of constant checking

### DIFF
--- a/inc/class-statifyblacklist-admin.php
+++ b/inc/class-statifyblacklist-admin.php
@@ -126,11 +126,11 @@ class StatifyBlacklist_Admin extends StatifyBlacklist {
 	 */
 	public static function cleanup_database(): void {
 		// Check user permissions.
-		if ( ! current_user_can( 'manage_options' ) && ! ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ! wp_doing_cron() ) {
 			die( esc_html__( 'Are you sure you want to do this?', 'statify-blacklist' ) );
 		}
 
-		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+		if ( wp_doing_cron() ) {
 			$clean_ref = ( 1 === self::$options['referer']['cron'] );
 			$clean_trg = ( 1 === self::$options['target']['cron'] );
 		} else {

--- a/inc/class-statifyblacklist.php
+++ b/inc/class-statifyblacklist.php
@@ -109,7 +109,7 @@ class StatifyBlacklist {
 		}
 
 		// CronJob to clean up database.
-		if ( defined( 'DOING_CRON' ) && DOING_CRON &&
+		if ( wp_doing_cron() &&
 			( 1 === self::$options['referer']['cron'] || 1 === self::$options['target']['cron'] ) ) {
 			add_action( 'statify_cleanup', array( 'StatifyBlacklist_Admin', 'cleanup_database' ) );
 		}


### PR DESCRIPTION
The function is available since WP 4.8 and defaults to the same logic but applies an additional filter internally.