### PR TITLE
introduce PHPStan static code analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,4 +15,5 @@
 /package.json
 /package-lock.json
 /phpcs.xml
+/phpstan.neon
 /phpunit.xml

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@ composer.lock export-ignore
 CONTRIBUTING.md export-ignore
 package.json export-ignore
 phpcs.xml export-ignore
+phpstan.neon export-ignore
 phpunit.xml export-ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,20 @@ jobs:
         run: composer install --no-interaction
       - name: Code style checks for PHP
         run: composer test-cs
+
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: composer
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+      - name: PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     "phpunit/phpunit": "^8|^9",
     "slowprog/composer-copy-file": "~0.3",
     "squizlabs/php_codesniffer": "^3.13",
+    "szepeviktor/phpstan-wordpress": "^v2.0",
+    "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan": "^2.1",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "wp-coding-standards/wpcs": "^3.2"
   },
@@ -42,12 +45,16 @@
     ],
     "fix-cs": [
       "phpcbf --standard=phpcs.xml"
+    ],
+    "phpstan": [
+      "phpstan analyse --memory-limit=1G"
     ]
   },
   "config": {
     "allow-plugins": {
       "composer/installers": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  level: 3
+  paths:
+    - inc/
+    - statify-blacklist.php
+  ignoreErrors:
+    - message: '/^Constant STATIFYBLACKLIST_BASE not found\.$/'
+      path: inc/


### PR DESCRIPTION
Add PHPStan and WP stubs to our dev-dependencies and configure a CI workflow to run the analysis.

We can start at level 3 without any additional code changes required.