### PR TITLE
simplify multisite iteration in (un)install routine

### DIFF
--- a/inc/class-statifyblacklist-system.php
+++ b/inc/class-statifyblacklist-system.php
@@ -33,19 +33,10 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 	public static function install( bool $network_wide = false ): void {
 		// Create tables for each site in a network.
 		if ( $network_wide && is_multisite() ) {
-			if ( function_exists( 'get_sites' ) ) {
-				$sites = get_sites();
-			} else {
-				return;
-			}
+			$sites = get_sites( array( 'fields' => 'ids' ) );
 
 			foreach ( $sites as $site ) {
-				if ( is_array( $site ) ) {
-					$site_id = $site['blog_id'];
-				} else {
-					$site_id = $site->blog_id;
-				}
-				self::install_site( $site_id );
+				self::install_site( $site );
 			}
 
 			restore_current_blog();
@@ -87,19 +78,10 @@ class StatifyBlacklist_System extends StatifyBlacklist {
 		if ( is_multisite() ) {
 			$old = get_current_blog_id();
 
-			if ( function_exists( 'get_sites' ) ) {
-				$sites = get_sites();
-			} else {
-				return;
-			}
+			$sites = get_sites( array( 'fields' => 'ids' ) );
 
 			foreach ( $sites as $site ) {
-				if ( is_array( $site ) ) {
-					$site_id = $site['blog_id'];
-				} else {
-					$site_id = $site->blog_id;
-				}
-				self::uninstall_site( $site_id );
+				self::uninstall_site( $site );
 			}
 
 			switch_to_blog( $old );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
   paths:
     - inc/
     - statify-blacklist.php


### PR DESCRIPTION
`get_sites()`[^1] is guaranteed to be available on WP 5.1 and later and never returns the legacy array of arrays structure. Drop the redundant checks.

We also do not require the fill site object, so let's just fetch IDs.

[^1]: https://developer.wordpress.org/reference/functions/get_sites/